### PR TITLE
Fix for issue #16, now reads contractions normally

### DIFF
--- a/js/speakit.js
+++ b/js/speakit.js
@@ -548,8 +548,8 @@
 	    str = [],
 	    tmpstr =[],
 	    maxlength = 90, // Max length of one sentence this is Google's fault :)
-	    badchars = ["+","#","@","-","<",">","\n","!","?",":","&",'"',"  ","。"],
-	    replaces = [" plus "," sharp "," at ","","","","",".",".","."," and "," "," ","."];
+	    badchars = ["+","#","@","-","<",">","\n","!","?",":","&",'"',"  ","。","‘","’"],
+	    replaces = [" plus "," sharp "," at ","","","","",".",".","."," and "," "," ",".","'","'"];
 			
 	    for(var i in badchars) // replacing bad chars
 	    {


### PR DESCRIPTION
This fixes issue #16 which seems to be caused by it not being able to interpret unicode single quotes like ascii single quotes. Since you're already replacing a lot of symbols like that, it seemed correct to just add these to the end.